### PR TITLE
Add ability to store API secrets in Secrets Manager

### DIFF
--- a/cloud_formation/canvas_data_aws.yaml
+++ b/cloud_formation/canvas_data_aws.yaml
@@ -24,9 +24,19 @@ Parameters:
   ApiSecretParameter:
     Type: String
     Description: Your Canvas Data API Secret
+  ApiSecretsManagerParameter:
+    Type: String
+    Description: An optional Secrets Manager secret that contains the api_key and api_secret (alternative to ApiKeyParameter and ApiSecretParameter).
+    Default: ""
   EmailAddressParameter:
     Type: String
     Description: Your email address. This will be used to send you notifications about the success or failure of the data synchronization process.
+
+Conditions:
+  HasApiSecretsManager: !And
+    - !Equals [ !Ref ApiKeyParameter, "" ]
+    - !Equals [ !Ref ApiSecretParameter, "" ]
+    - !Not [ !Equals [ !Ref ApiSecretsManagerParameter, "" ] ]
 
 Resources:
 
@@ -182,6 +192,20 @@ Resources:
                     - !Ref AWS::Region
                     - !Ref AWS::AccountId
                     - "function:canvas-data-*"
+  SyncLambdaFunctionSMPolicy:
+    Type: AWS::IAM::Policy
+    Condition: HasApiSecretsManager
+    Properties:
+      Roles:
+        - !Ref SyncLambdaFunctionRole
+      PolicyName: APISecretsManager
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          -
+            Effect: "Allow"
+            Action: "secretsmanager:GetSecretValue"
+            Resource: !Sub "arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:${ApiSecretsManagerParameter}-??????"
 
   SyncLambdaFunction:
     Type: AWS::Lambda::Function
@@ -196,6 +220,7 @@ Resources:
           ENV : !Ref EnvironmentParameter
           api_key: !Ref ApiKeyParameter
           api_secret: !Ref ApiSecretParameter
+          api_sm_id: !Ref ApiSecretsManagerParameter
           fetch_function_name: !Ref FetchLambdaFunction
           s3_bucket: !Ref S3Bucket
           sns_topic: !Ref SNSTopic

--- a/lambda/sync-canvas-data-files.py
+++ b/lambda/sync-canvas-data-files.py
@@ -14,8 +14,14 @@ def lambda_handler(event, context):
 
     dry_run = True if os.environ.get('dry_run', '').lower() == 'true' else False
 
-    api_key = os.environ['api_key']
-    api_secret = os.environ['api_secret']
+    sm  = boto3.client('secretsmanager')
+    if os.environ.get('api_sm_id'):
+        res = sm.get_secret_value(SecretId=os.environ['api_sm_id'])
+        api_sm = json.loads(res['SecretString'])
+        api_key, api_secret = api_sm['api_key'], api_sm['api_secret']
+    else:
+        api_key = os.environ['api_key']
+        api_secret = os.environ['api_secret']
 
     fetch_function_name = os.environ.get('fetch_function_name')
 


### PR DESCRIPTION
Instead of providing the API Key and Secret value via parameters and environment variables, instead allow them to be stored in Secrets Manager. This provides encryption, and also enables the ability (in the future) to write a Lambda to automatically rotate the secret with Canvas.

These code changes should be optional and backwards compatible.